### PR TITLE
fix: The VAD model cannot use ModelScope's cache for loading when offline.

### DIFF
--- a/pysilero/pickable_session.py
+++ b/pysilero/pickable_session.py
@@ -30,7 +30,12 @@ class PickableSession:
         opts.log_severity_level = 3
 
         assert version in ["v4", "v5"]
-        repo_dir = snapshot_download("pengzhendong/silero-vad")
+        try:
+            repo_dir = snapshot_download("pengzhendong/silero-vad")
+        except:
+            import os
+            from modelscope.utils.file_utils import get_default_modelscope_cache_dir
+            repo_dir = os.path.join(get_default_modelscope_cache_dir(), "models/pengzhendong/silero-vad")
         self.model_path = f"{repo_dir}/{version}/silero_vad.onnx"
         self.init_session = partial(ort.InferenceSession, sess_options=opts, providers=["CPUExecutionProvider"])
         self.sess = self.init_session(self.model_path)


### PR DESCRIPTION

在离线环境中使用时,发现即使我将手动下载的内容放到.cache下的modelscope缓存位置,仍然无法正常使用. 
通过源代码发现,每次会进行强制下载,缺少下载失败后的异常处理. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when downloading the Silero VAD model by adding a fallback mechanism if the initial download attempt fails. The application will now attempt to locate the model locally if the download cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->